### PR TITLE
Jruby support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ notifications:
   email: false
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
     - rvm: rbx-19mode

--- a/sidekiq-encryptor.gemspec
+++ b/sidekiq-encryptor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'yard'
-  gem.add_development_dependency 'redcarpet'
+  gem.add_development_dependency 'kramdown'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-redis_helper'


### PR DESCRIPTION
This uses Kramdown instead of Redcarpet for compatibility with jRuby. It also does not allow jRuby test failures on Travis anymore.

All tests are green.

I have yet to test this gem in a real jRuby app before removing that part about "actively tested" in the README, but I think this is a start :)

Thank you for open sourcing this and for your work!
