### PR TITLE
Use proper syntax for rubinius on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby-19mode
-  - rbx-19mode
+  - rbx
 branches:
   only:
     - master
@@ -12,4 +12,4 @@ notifications:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
-    - rvm: rbx-19mode
+    - rvm: rbx


### PR DESCRIPTION
This uses the correct name for Rubinius on Travis so tests will run with the proper Rubinius version there.

For more details read this nice nice blogpost by @brixen on this: http://rubini.us/2013/12/03/testing-with-rbx-on-travis

Thanks again :)
